### PR TITLE
chore: upgrade hugo to v0.92.2

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@ publish = "public"
 command = "git submodule update --init --recursive --force --remote && hugo --gc --minify -b https://www.rickroche.com/"
 
 [context.production.environment]
-HUGO_VERSION = "0.85.0"
+HUGO_VERSION = "0.92.2"
 HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
 
@@ -12,13 +12,13 @@ HUGO_ENABLEGITINFO = "true"
 command = "git submodule update --init --recursive --force --remote && hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
 
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.85.0"
+HUGO_VERSION = "0.92.2"
 
 [context.branch-deploy]
 command = "git submodule update --init --recursive --force --remote && hugo --gc --minify -b $DEPLOY_PRIME_URL"
 
 [context.branch-deploy.environment]
-HUGO_VERSION = "0.85.0"
+HUGO_VERSION = "0.92.2"
 
 [dev]
 base = "site/"


### PR DESCRIPTION
This PR upgrade hugo from v0.85 to [v0.92.2](https://github.com/gohugoio/hugo/releases/tag/v0.92.2)